### PR TITLE
Update criticalcommons to use DRF api.

### DIFF
--- a/parsers/criticalcommons/handler.php
+++ b/parsers/criticalcommons/handler.php
@@ -1,11 +1,13 @@
 <?php
 
-$url = 'http://criticalcommons.org/cc/playlist?SearchableText='.$query;
+$url = 'https://criticalcommons.org/api/v1/search?q='.$query;
 
-// Generic HTTP handler
-session_start();
-$opts = array('http' => array('header'=> 'Cookie: ' . @$_SERVER['HTTP_COOKIE']."\r\n"));
-$context = stream_context_create($opts);
-session_write_close();
-$content = file_get_contents($url, false, $context);
+// Generic HTTPS handler
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, $url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+$content = curl_exec($ch);
+curl_close($ch);
 ?>

--- a/parsers/criticalcommons/parser.js
+++ b/parsers/criticalcommons/parser.js
@@ -1,53 +1,32 @@
 (function( $ ) {
 	
-    $.fn.parse = function(options) {
-    	if (!options.query.length) throw "Critical Commons requires at least one search term to be entered into the search field.";
-    	var model = new $.fn.spreadsheet_model(options);
-    	model.parse = parse;
-    	model.fetch('xml');
-    };
-    
+	$.fn.parse = function(options) {
+		if (!options.query.length) throw "Critical Commons requires at least one search term to be entered into the search field.";
+		var model = new $.fn.spreadsheet_model(options);
+		model.parse = parse;
+		model.fetch('json');
+	};
+		
+		
 	function parse(data, archive) {
-        var results = {};
-        $(data).find('item').each(function() {
-        	var sourceLocation = this.attributes['rdf:about'].value;
-        	var obj;
-        	obj = this.getElementsByTagName('link');
-        	var uri = ('undefined'!=obj[0]) ? obj[0].childNodes[0].nodeValue : '';
-        	if (!uri.length) return;
-        	// TODO: URI is None/None
-        	obj = this.getElementsByTagName('title');
-        	var title = ('undefined'!=typeof(obj[0]) && 'undefined'!=typeof(obj[0].childNodes[0])) ? obj[0].childNodes[0].nodeValue : '';
-        	obj = this.getElementsByTagName('description');
-        	var desc = ('undefined'!=typeof(obj[0]) && 'undefined'!=typeof(obj[0].childNodes[0])) ? obj[0].childNodes[0].nodeValue : '';
-        	obj = this.getElementsByTagNameNS("http://purl.org/dc/terms/", "date");        	
-        	var date = ('undefined'!=typeof(obj[0]) && 'undefined'!=typeof(obj[0].childNodes[0])) ? obj[0].childNodes[0].nodeValue : '';
-        	obj = this.getElementsByTagNameNS("http://purl.org/dc/terms/", "creator");
-        	var creator = ('undefined'!=typeof(obj[0]) && 'undefined'!=typeof(obj[0].childNodes[0])) ? obj[0].childNodes[0].nodeValue : '';
-        	obj = this.getElementsByTagNameNS("http://purl.org/dc/terms/", "publisher");
-        	var publisher = ('undefined'!=typeof(obj[0]) && 'undefined'!=typeof(obj[0].childNodes[0])) ? obj[0].childNodes[0].nodeValue : ''; 
-        	obj = this.getElementsByTagNameNS("http://purl.org/dc/terms/", "rights");
-        	var rights = ('undefined'!=typeof(obj[0]) && 'undefined'!=typeof(obj[0].childNodes[0])) ? obj[0].childNodes[0].nodeValue : '';
-        	obj = this.getElementsByTagNameNS("http://purl.org/dc/terms/", "type");
-        	var type = ('undefined'!=typeof(obj[0]) && 'undefined'!=typeof(obj[0].childNodes[0])) ? obj[0].childNodes[0].nodeValue : '';         	
-        	obj = this.getElementsByTagNameNS("http://simile.mit.edu/2003/10/ontologies/artstor#", "thumbnail");
-        	var thumb = ('undefined'!=typeof(obj[0]) && 'undefined'!=typeof(obj[0].childNodes[0])) ? obj[0].attributes['url'].value : '';          	
-        	results[uri] = {
-        		'http://simile.mit.edu/2003/10/ontologies/artstor#thumbnail':[{type:'uri',value:thumb}],
-        		'http://purl.org/dc/terms/title':[{type:'literal',value:title}],
-        		'http://purl.org/dc/terms/description':[{type:'literal',value:desc}],
-        		'http://purl.org/dc/terms/source':[{type:'literal',value:archive.title}],
-        		'http://purl.org/dc/terms/date':[{type:'literal',value:date}],
-        		'http://purl.org/dc/terms/creator':[{type:'literal',value:creator}],
-        		'http://purl.org/dc/terms/publisher':[{type:'literal',value:publisher}],
-        		'http://purl.org/dc/terms/rights':[{type:'literal',value:rights}],
-        		'http://purl.org/dc/terms/type':[{type:'literal',value:type}],
-        		'http://simile.mit.edu/2003/10/ontologies/artstor#url':[{type:'uri',value:uri}],
-        		'http://simile.mit.edu/2003/10/ontologies/artstor#sourceLocation':[{type:'uri',value:sourceLocation}],
-        	};
-        });
-        console.log(results);
-        this.opts.complete_callback(results, archive);
+	  let results = data.results.reduce( (obj, vid) => {
+		  let thumb = 'https://criticalcommons.org' + vid.thumbnail_url;
+		  obj[vid.url] = {
+			  'http://simile.mit.edu/2003/10/ontologies/artstor#thumbnail':[{type:'uri',value:thumb}],
+			  'http://simile.mit.edu/2003/10/ontologies/artstor#url':[{type:'uri',value:vid.url}],
+			  'http://purl.org/dc/terms/title':[{type:'literal',value:vid.title}],
+			  'http://purl.org/dc/terms/source':[{type:'literal',value:archive.title}],
+			  'http://simile.mit.edu/2003/10/ontologies/artstor#sourceLocation':[{type:'uri',value:vid.url}],
+			  'http://purl.org/dc/terms/date':[{type:'uri',value:vid.add_date}],
+			  'http://purl.org/dc/terms/creator':[{type:'uri',value:vid.author_name}],
+		  }
+		  if(vid.description && vid.description.length) {
+			  obj[vid.url]['http://purl.org/dc/terms/description'] = [{type:'literal',value:vid.description}];
+		  }
+		  return obj;
+	  }, {});
+	  console.log(results);
+    this.opts.complete_callback(results, archive);
 	};
     
 }( jQuery ));


### PR DESCRIPTION
This PR restores functionality of the criticalcommons parser by:
- Pointing the handler to the ciriticalcommons Django Rest Framework api
- Parsing the json returned from the api search